### PR TITLE
Fix stdout on debugger

### DIFF
--- a/executor/debugger.go
+++ b/executor/debugger.go
@@ -219,7 +219,8 @@ func (d *Debugger) handleCommand() error {
 func (d *Debugger) handleCommandWithArg(name, arg string) error {
 	n, err := strconv.Atoi(arg)
 	if err != nil {
-		return err
+		fmt.Printf("Invalid command arguments: \"%s %s\", Try \"help\"\n", name, arg)
+		return nil
 	}
 
 	switch name {

--- a/executor/debugger.go
+++ b/executor/debugger.go
@@ -103,9 +103,8 @@ func NewDebugger(executor *Executor) *Debugger {
 	}
 
 	debugger.executor.Output = func(value string) {
-		if debugger.state == DebuggerStateInterrupt {
-			debugger.stdout += value
-		} else {
+		debugger.stdout += value
+		if debugger.state == DebuggerStateContinue {
 			fmt.Printf(value)
 		}
 	}


### PR DESCRIPTION
## What

- Make it possible to output invalid argument error for debugger command
- Stop the debugger when vm runtime error occured
-  Stdout buffer is saved even if the debugger mode is switched.